### PR TITLE
fixed _server.coffee output_static octal

### DIFF
--- a/_server.coffee
+++ b/_server.coffee
@@ -36,7 +36,7 @@ if is_build
   # Remove previous build
   wrench.rmdirSyncRecursive('output_static', true)
   # Create root directory
-  wrench.mkdirSyncRecursive('output_static', 0777)
+  wrench.mkdirSyncRecursive('output_static', 0o0777)
   # Copy public assets
   wrench.copyDirSyncRecursive('public/assets', 'output_static/assets')
   wrench.copyDirSyncRecursive('public/scripts', 'output_static/scripts')


### PR DESCRIPTION
ThreeNodes.js wasn't running on Ubuntu 12.04 with node.js v0.6.15

```
rportugal@rportugal-ubuntu:~/Desktop/ThreeNodes.js$ node server.js 

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
SyntaxError: In /home/rportugal/Desktop/ThreeNodes.js/_server.coffee, octal literal '0777' must be prefixed with '0o' on line 39
    at SyntaxError (unknown source)
    at Lexer.error (/home/rportugal/Desktop/ThreeNodes.js/node_modules/coffee-script/lib/coffee-script/lexer.js:686:13)
    at Lexer.numberToken (/home/rportugal/Desktop/ThreeNodes.js/node_modules/coffee-script/lib/coffee-script/lexer.js:138:14)
    at Lexer.tokenize (/home/rportugal/Desktop/ThreeNodes.js/node_modules/coffee-script/lib/coffee-script/lexer.js:35:159)
    at /home/rportugal/Desktop/ThreeNodes.js/node_modules/coffee-script/lib/coffee-script/coffee-script.js:43:32
    at Object..coffee (/home/rportugal/Desktop/ThreeNodes.js/node_modules/coffee-script/lib/coffee-script/coffee-script.js:19:17)
    at Module.load (module.js:348:31)
    at Function._load (module.js:308:12)
    at Module.require (module.js:354:17)
    at require (module.js:370:17)
```
