### PR TITLE
Fix Deprecated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Experimental
 This is an experiment to make something like "vvvv" in javascript, html and webgl.
 
-Live demo: http://idflood.github.com/ThreeNodes.js/
+Live demo: https://idflood.github.io/ThreeNodes.js/
 
 ## Key principles
 - modular


### PR DESCRIPTION
http -> https,
github.com -> github.io (https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/)
Be sure to change the link in the "About" section of the repo as well